### PR TITLE
Added support for optional data channel

### DIFF
--- a/src/ConsoleTestApp/NLog.config
+++ b/src/ConsoleTestApp/NLog.config
@@ -21,6 +21,7 @@
       xsi:type="SplunkHttpEventCollector"
       ServerUrl="https://localhost:8088"
       Token="bff36dda-e0fc-4cdd-b2dc-50418ee98ead"
+      Channel=""
       RetriesOnError="0"
       IgnoreSslErrors="true"
       layout="${message} ${exception:format=tostring}"

--- a/src/NLog.Targets.Splunk.Tests/SplunkHttpEventCollectorTests.cs
+++ b/src/NLog.Targets.Splunk.Tests/SplunkHttpEventCollectorTests.cs
@@ -23,6 +23,7 @@ namespace NLog.Targets.Splunk.Tests
             // Step 3. Set target properties 
             splunkHttpEventCollector.ServerUrl = new Uri("http://localhost:8088");
             splunkHttpEventCollector.Token = "bff36dda-e0fc-4cdd-b2dc-50418ee98ead";
+            splunkHttpEventCollector.Channel = "bff36dda-e0fc-4cdd-b2dc-50418ee98ead";
             splunkHttpEventCollector.RetriesOnError = 0;
 
             // Step 4. Define rules

--- a/src/NLog.Targets.Splunk/SplunkHttpEventCollector.cs
+++ b/src/NLog.Targets.Splunk/SplunkHttpEventCollector.cs
@@ -28,10 +28,18 @@ namespace NLog.Targets.Splunk
         /// Gets or sets the Splunk HTTP Event Collector token.
         /// </summary>
         /// <value>
-        /// The SPlunk HTTP Event Collector token.
+        /// The Splunk HTTP Event Collector token.
         /// </value>
         [RequiredParameter]
         public string Token { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional Splunk HTTP Event Collector data channel.
+        /// </summary>
+        /// <value>
+        /// The Splunk HTTP Event Collector data channel.
+        /// </value>
+        public string Channel { get; set; }
 
         /// <summary>
         /// Gets or sets the number of retries on error.
@@ -105,6 +113,7 @@ namespace NLog.Targets.Splunk
             _hecSender = new HttpEventCollectorSender(
                 ServerUrl,                                                                          // Splunk HEC URL
                 Token,                                                                              // Splunk HEC token *GUID*
+                Channel,                                                                            // Splunk HEC data channel *GUID*
                 GetMetaData(null),                                                                  // Metadata
                 HttpEventCollectorSender.SendMode.Sequential,                                       // Sequential sending to keep message in order
                 BatchSizeBytes == 0 && BatchSizeCount == 0 ? 0 : 250,                               // BatchInterval - Set to 0 to disable


### PR DESCRIPTION
- Added support for Splunk HEC Data channel.
- Debug and Release configurations compile and all tests pass. 
- Channel value may be omitted from config file, but included as an example.
- See http://dev.splunk.com/view/event-collector/SP-CAAAE6P#chann