### PR TITLE
Apply keep-alive header.

### DIFF
--- a/src/NLog.Targets.Splunk/SplunkHttpEventCollector.cs
+++ b/src/NLog.Targets.Splunk/SplunkHttpEventCollector.cs
@@ -87,6 +87,8 @@ namespace NLog.Targets.Splunk
         /// <value>0 = Use default limit. Default = 10</value>
         public int MaxConnectionsPerServer { get; set; } = 10;
 
+        public bool UseHttpVersion10Hack { get; set; } = false;
+
         /// <summary>
         /// Configuration of additional properties to include with each LogEvent (Ex. ${logger}, ${machinename}, ${threadid} etc.)
         /// </summary>
@@ -143,7 +145,8 @@ namespace NLog.Targets.Splunk
                 BatchSizeCount,                                                                     // BatchSizeCount - Set to 0 to disable
                 IgnoreSslErrors,                                                                    // Enable Ssl Error ignore for self singed certs *BOOL*
                 MaxConnectionsPerServer,
-                new HttpEventCollectorResendMiddleware(RetriesOnError).Plugin                       // Resend Middleware with retry
+                new HttpEventCollectorResendMiddleware(RetriesOnError).Plugin,                      // Resend Middleware with retry
+                httpVersion10Hack: UseHttpVersion10Hack
             );
             _hecSender.OnError += (e) => { InternalLogger.Error(e, "SplunkHttpEventCollector(Name={0}): Failed to send LogEvents", Name); };
         }


### PR DESCRIPTION
This is a workaround to prevent socket exhaustion.

We use this package in our azure web-apps to forward log messages to Splunk. We ended up losing log messages due to socket/port exhaustion having thousands of connections in the TIME_WAIT state.

Batching the log messages reduced the problem but did not solve it.

After many tests, I recovered that the connection is closed after each request. Event setting the httpClient.DefaultRequestHeaders.ConnectionClose to false (which should be the default value since HTTP v1.1) was not recognized by the HEC endpoint. Only switching back to HTTP v1.0 and setting the keep-alive header worked.

I assume this as a workaround. In my opinion, this has to be fixed in the HEC endpoint.