### PR TITLE
Add UseProxy property

### DIFF
--- a/src/NLog.Targets.Splunk/SplunkHttpEventCollector.cs
+++ b/src/NLog.Targets.Splunk/SplunkHttpEventCollector.cs
@@ -88,6 +88,14 @@ namespace NLog.Targets.Splunk
         public int MaxConnectionsPerServer { get; set; } = 10;
 
         /// <summary>
+        /// Gets or sets whether to use default web proxy.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> = use default web proxy. <c>false</c> = use no proxy. Default is <c>true</c> 
+        /// </value>
+        public bool UseProxy { get; set; } = true;
+
+        /// <summary>
         /// Configuration of additional properties to include with each LogEvent (Ex. ${logger}, ${machinename}, ${threadid} etc.)
         /// </summary>
         public override IList<TargetPropertyWithContext> ContextProperties { get; } = new List<TargetPropertyWithContext>();
@@ -142,6 +150,7 @@ namespace NLog.Targets.Splunk
                 BatchSizeBytes,                                                                     // BatchSizeBytes - Set to 0 to disable
                 BatchSizeCount,                                                                     // BatchSizeCount - Set to 0 to disable
                 IgnoreSslErrors,                                                                    // Enable Ssl Error ignore for self singed certs *BOOL*
+                UseProxy,                                                                           // UseProxy - Set to false to disable
                 MaxConnectionsPerServer,
                 new HttpEventCollectorResendMiddleware(RetriesOnError).Plugin                       // Resend Middleware with retry
             );


### PR DESCRIPTION
By default HttpClient uses default system web proxy when performing requests. This setting will allow to override this behavior. 
Also MaxConnectionsPerServer setting was ignored when IgnoreSslErrors setting was not set. This pull request fixes it.